### PR TITLE
feat(lua54): Refactor and rename metatable-related methods for clarity

### DIFF
--- a/lua54/table.go
+++ b/lua54/table.go
@@ -90,15 +90,15 @@ func (s *State) Next(idx int) bool {
 	return s.ffi.LuaNext(s.luaL, idx) != 0
 }
 
-func (s *State) GetMetaTable(index int) int {
+func (s *State) GeIMetaTable(index int) int {
 	return s.ffi.LuaGetmetatable(s.luaL, index)
 }
 
-func (s *State) SetMetaTable(index int) int {
+func (s *State) SetIMetaTable(index int) int {
 	return s.ffi.LuaSetmetatable(s.luaL, index)
 }
 
-func (s *State) LNewMetaTable(tname string) (has bool, err error) {
+func (s *State) NewMetaTable(tname string) (has bool, err error) {
 	p, err := tools.BytePtrFromString(tname)
 	if err != nil {
 		return
@@ -107,7 +107,7 @@ func (s *State) LNewMetaTable(tname string) (has bool, err error) {
 	return
 }
 
-func (s *State) LSetMetaTable(tname string) (err error) {
+func (s *State) SetMetaTable(tname string) (err error) {
 	p, err := tools.BytePtrFromString(tname)
 	if err != nil {
 		return
@@ -116,11 +116,11 @@ func (s *State) LSetMetaTable(tname string) (err error) {
 	return
 }
 
-func (s *State) LGetMetaTable(tname string) (typ int, err error) {
+func (s *State) GetMetaTable(tname string) (typ int, err error) {
 	return s.GetField(LUA_REGISTRYINDEX, tname)
 }
 
-func (s *State) LGetMetaField(obj int, e string) (typ int, err error) {
+func (s *State) GetMetaField(obj int, e string) (typ int, err error) {
 	p, err := tools.BytePtrFromString(e)
 	if err != nil {
 		return
@@ -129,7 +129,7 @@ func (s *State) LGetMetaField(obj int, e string) (typ int, err error) {
 	return
 }
 
-func (s *State) LCallMeta(obj int, e string) (has bool, err error) {
+func (s *State) CallMeta(obj int, e string) (has bool, err error) {
 	p, err := tools.BytePtrFromString(e)
 	if err != nil {
 		return

--- a/lua54/table_test.go
+++ b/lua54/table_test.go
@@ -469,18 +469,18 @@ func (s *Suite) TestTableMeta(assert *require.Assertions, L *lua.State) {
 	})
 	L.SetTable(mtIdx)
 
-	L.SetMetaTable(tblIdx)
+	L.SetIMetaTable(tblIdx)
 	L.PushValue(tblIdx)
-	assert.Equal(1, L.GetMetaTable(-1))
+	assert.Equal(1, L.GeIMetaTable(-1))
 	assert.Equal(lua.LUA_TTABLE, L.Type(-1))
 	L.Pop(2)
 
-	assert.Equal(1, L.GetMetaTable(tblIdx))
-	typ, err := L.LGetMetaField(tblIdx, "__call")
+	assert.Equal(1, L.GeIMetaTable(tblIdx))
+	typ, err := L.GetMetaField(tblIdx, "__call")
 	assert.NoError(err)
 	assert.Equal(lua.LUA_TFUNCTION, typ)
 
-	has, err := L.LCallMeta(tblIdx, "__call")
+	has, err := L.CallMeta(tblIdx, "__call")
 	assert.NoError(err)
 	assert.True(has)
 	assert.Equal(lua.LUA_TSTRING, L.Type(-1))
@@ -488,12 +488,12 @@ func (s *Suite) TestTableMeta(assert *require.Assertions, L *lua.State) {
 
 	L.SetTop(tblIdx)
 
-	has, err = L.LNewMetaTable("mt")
+	has, err = L.NewMetaTable("mt")
 	assert.NoError(err)
 	assert.False(has)
 	L.Pop(1)
 
-	has, err = L.LNewMetaTable("mt")
+	has, err = L.NewMetaTable("mt")
 	assert.NoError(err)
 	assert.True(has)
 	L.PushString("__call")
@@ -504,19 +504,19 @@ func (s *Suite) TestTableMeta(assert *require.Assertions, L *lua.State) {
 	L.SetTable(-3)
 	L.SetTop(tblIdx)
 
-	assert.NoError(L.LSetMetaTable("mt"))
-	typ, err = L.LGetMetaField(tblIdx, "__call")
+	assert.NoError(L.SetMetaTable("mt"))
+	typ, err = L.GetMetaField(tblIdx, "__call")
 	assert.NoError(err)
 	assert.Equal(lua.LUA_TFUNCTION, typ)
 
-	typ, err = L.LGetMetaTable("mt")
+	typ, err = L.GetMetaTable("mt")
 	assert.NoError(err)
 	assert.Equal(lua.LUA_TTABLE, typ)
-	typ, err = L.LGetMetaTable("non_existent")
+	typ, err = L.GetMetaTable("non_existent")
 	assert.NoError(err)
 	assert.Equal(lua.LUA_TNIL, typ)
 
-	has, err = L.LCallMeta(tblIdx, "__call")
+	has, err = L.CallMeta(tblIdx, "__call")
 	assert.NoError(err)
 	assert.True(has)
 	assert.Equal(lua.LUA_TSTRING, L.Type(-1))

--- a/lua54/userdata_test.go
+++ b/lua54/userdata_test.go
@@ -82,9 +82,9 @@ func (s *Suite) TestUserData(assert *require.Assertions, L *lua.State) {
 	udIdx = L.GetTop()
 	mtName := "MyMeta"
 	L.NewTable()
-	L.SetMetaTable(udIdx)
-	L.LNewMetaTable(mtName)
-	L.SetMetaTable(udIdx)
+	L.SetIMetaTable(udIdx)
+	L.NewMetaTable(mtName)
+	L.SetIMetaTable(udIdx)
 
 	ptr, err := L.CheckUserData(udIdx, mtName)
 	assert.NoError(err)
@@ -95,7 +95,7 @@ func (s *Suite) TestUserData(assert *require.Assertions, L *lua.State) {
 	assert.Equal(ptr, ptr)
 
 	L.NewTable()
-	L.SetMetaTable(udIdx)
+	L.SetIMetaTable(udIdx)
 	ptr, err = L.TestUserData(udIdx, mtName)
 	assert.NoError(err)
 	assert.Nil(ptr)
@@ -138,7 +138,7 @@ func (s *Suite) TestUserData(assert *require.Assertions, L *lua.State) {
 		}
 	})
 	L.SetTable(-3)
-	L.SetMetaTable(-2)
+	L.SetIMetaTable(-2)
 
 	L.SetGlobal("userDataTest")
 


### PR DESCRIPTION
- Rename various metatable API methods (LNewMetaTable, LSetMetaTable, LGetMetaTable, LGetMetaField, LCallMeta) to more concise and standard names (NewMetaTable, SetMetaTable, GetMetaTable, GetMetaField, CallMeta)

- Rename GetMetaTable/SetMetaTable for index-based metatables to GeIMetaTable/SetIMetaTable to clarify distinction

- Update corresponding usage in test code to reflect new method names for consistency and clarity