### PR TITLE
chore: update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # lua
 Lua Go binding in purego
 
+## Caution
+
+⚠️This library is **working in progress** 🚧 And APIs are not stable yet, maybe cause breaking changes many times. I make it public only for unlimited GitHub Actions minutes. It is not recommended to use at this moment.
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
The private repository has limited GitHub Actions usage, with the free plan allowing only 2,000 minutes per month. Let's make it public instead.