### PR TITLE
fix(lua54): fix incorrect lua_cfunction convertion

### DIFF
--- a/ffi.go
+++ b/ffi.go
@@ -18,9 +18,9 @@ type LuaReader func(L unsafe.Pointer, ud unsafe.Pointer, sz *int) *byte
 // See: https://www.lua.org/manual/5.4/manual.html#lua_Alloc
 type LuaAlloc func(ud unsafe.Pointer, ptr unsafe.Pointer, osize, nsize int) unsafe.Pointer
 
-// LuaCFunction is the Go equivalent of the C lua_CFunction for stack-based callbacks.
+// LuaGoFunction is the Go equivalent of the C lua_CFunction for stack-based callbacks.
 // See: https://www.lua.org/manual/5.4/manual.html#lua_CFunction
-type LuaCFunction func(L unsafe.Pointer) int
+type LuaGoFunction func(L unsafe.Pointer) int
 
 // LuaKFunction is the Go equivalent for lua_KFunction, supporting continuation-style yields from C to Lua.
 // See: https://www.lua.org/manual/5.4/manual.html#lua_KFunction
@@ -45,7 +45,7 @@ type ffi struct {
 	LuaClosethread func(L unsafe.Pointer, from unsafe.Pointer) int    `ffi:"lua_closethread,gte=504"`
 	LuaResetthread func(L unsafe.Pointer) int                         `ffi:"lua_resetthread,gte=504"`
 
-	LuaAtpanic func(L unsafe.Pointer, panicf LuaCFunction) unsafe.Pointer `ffi:"lua_atpanic,gte=503"`
+	LuaAtpanic func(L unsafe.Pointer, panicf LuaGoFunction) unsafe.Pointer `ffi:"lua_atpanic,gte=503"`
 
 	LuaVersion func(L unsafe.Pointer) float64 `ffi:"lua_version,gte=503"`
 
@@ -85,15 +85,16 @@ type ffi struct {
 	LuaLen      func(L unsafe.Pointer, idx int)                        `ffi:"lua_len,gte=503"`
 
 	// Push functions
-	LuaPushnil           func(L unsafe.Pointer)                         `ffi:"lua_pushnil,gte=503"`
-	LuaPushnumber        func(L unsafe.Pointer, n float64)              `ffi:"lua_pushnumber,gte=503"`
-	LuaPushinteger       func(L unsafe.Pointer, n int64)                `ffi:"lua_pushinteger,gte=503"`
-	LuaPushlstring       func(L unsafe.Pointer, s *byte, len int) *byte `ffi:"lua_pushlstring,gte=503"`
-	LuaPushstring        func(L unsafe.Pointer, s *byte) *byte          `ffi:"lua_pushstring,gte=503"`
-	LuaPushcclousure     func(L unsafe.Pointer, f LuaCFunction, n int)  `ffi:"lua_pushcclosure,gte=503"`
-	LuaPushboolean       func(L unsafe.Pointer, b int) int              `ffi:"lua_pushboolean,gte=503"`
-	LuaPushlightuserdata func(L unsafe.Pointer, p unsafe.Pointer)       `ffi:"lua_pushlightuserdata,gte=503"`
-	LuaPushthread        func(L unsafe.Pointer) int                     `ffi:"lua_pushthread,gte=503"`
+	LuaPushnil           func(L unsafe.Pointer)                          `ffi:"lua_pushnil,gte=503"`
+	LuaPushnumber        func(L unsafe.Pointer, n float64)               `ffi:"lua_pushnumber,gte=503"`
+	LuaPushinteger       func(L unsafe.Pointer, n int64)                 `ffi:"lua_pushinteger,gte=503"`
+	LuaPushlstring       func(L unsafe.Pointer, s *byte, len int) *byte  `ffi:"lua_pushlstring,gte=503"`
+	LuaPushstring        func(L unsafe.Pointer, s *byte) *byte           `ffi:"lua_pushstring,gte=503"`
+	LuaPushgoclosure     func(L unsafe.Pointer, f LuaGoFunction, n int)  `ffi:"lua_pushcclosure,gte=503"`
+	LuaPushcclousure     func(L unsafe.Pointer, f unsafe.Pointer, n int) `ffi:"lua_pushcclosure,gte=503"`
+	LuaPushboolean       func(L unsafe.Pointer, b int) int               `ffi:"lua_pushboolean,gte=503"`
+	LuaPushlightuserdata func(L unsafe.Pointer, p unsafe.Pointer)        `ffi:"lua_pushlightuserdata,gte=503"`
+	LuaPushthread        func(L unsafe.Pointer) int                      `ffi:"lua_pushthread,gte=503"`
 
 	// Table and field functions
 	LuaCreatetable func(L unsafe.Pointer, narr, nrec int)         `ffi:"lua_createtable,gte=503"`
@@ -169,9 +170,9 @@ type ffi struct {
 	LuaLLoadfilex   func(L unsafe.Pointer, filename *byte, mode *byte) int                 `ffi:"luaL_loadfilex,gte=503"`
 	LuaLLoadbufferx func(L unsafe.Pointer, buff *byte, sz int, name *byte, mode *byte) int `ffi:"luaL_loadbufferx,gte=503"`
 
-	LuaLRef      func(L unsafe.Pointer, idx int) int                                `ffi:"luaL_ref,gte=503"`
-	LuaLUnref    func(L unsafe.Pointer, idx int, ref int)                           `ffi:"luaL_unref,gte=503"`
-	LuaLRequiref func(L unsafe.Pointer, modname *byte, openf LuaCFunction, glb int) `ffi:"luaL_requiref,gte=503"`
+	LuaLRef      func(L unsafe.Pointer, idx int) int                                 `ffi:"luaL_ref,gte=503"`
+	LuaLUnref    func(L unsafe.Pointer, idx int, ref int)                            `ffi:"luaL_unref,gte=503"`
+	LuaLRequiref func(L unsafe.Pointer, modname *byte, openf LuaGoFunction, glb int) `ffi:"luaL_requiref,gte=503"`
 }
 
 // getLuaVersion retrieves the Lua version from the loaded library.

--- a/stack.go
+++ b/stack.go
@@ -150,7 +150,7 @@ func (s *State) PushString(sv string) (ret *byte, err error) {
 // Caution: upvalues are read from the stack.
 // See: https://www.lua.org/manual/5.4/manual.html#lua_pushcclosure
 func (s *State) PushGoClousure(f GoFunc, n int) {
-	s.ffi.LuaPushcclousure(s.luaL, func(L unsafe.Pointer) int {
+	s.ffi.LuaPushgoclosure(s.luaL, func(L unsafe.Pointer) int {
 		state := s.clone(L)
 		return f(state)
 	}, n)
@@ -205,4 +205,16 @@ func (s *State) PushLightUserData(ud any) (err error) {
 // See: https://www.lua.org/manual/5.4/manual.html#lua_pushcfunction
 func (s *State) PushGoFunction(f GoFunc) {
 	s.PushGoClousure(f, 0)
+}
+
+// PushCFunction pushes a C function pointer as a Lua C closure with no upvalues.
+// Typically used with C function pointers from ToCFunction
+func (s *State) PushCFunction(f unsafe.Pointer) {
+	s.PushCClousure(f, 0)
+}
+
+// PushCClousure pushes a C function pointer as a Lua C closure with n upvalues.
+// Typically used with C function pointers from ToCFunction
+func (s *State) PushCClousure(f unsafe.Pointer, n int) {
+	s.ffi.LuaPushcclousure(s.luaL, f, n)
 }

--- a/state.go
+++ b/state.go
@@ -81,19 +81,14 @@ func (s *State) Close() {
 
 type GoFunc func(L *State) int
 
-// AtPanic sets a Go function as the Lua panic handler for this state, returning the old panic handler.
+// AtPanic sets a Go function as the Lua panic handler for this state, returning pointer of the old panic handler.
 // See: https://www.lua.org/manual/5.4/manual.html#lua_atpanic
-func (s *State) AtPanic(fn GoFunc) (old GoFunc) {
+func (s *State) AtPanic(fn GoFunc) (old unsafe.Pointer) {
 	panicf := func(L unsafe.Pointer) int {
 		state := s.clone(L)
 		return fn(state)
 	}
-	oldptr := s.ffi.LuaAtpanic(s.luaL, panicf)
-	oldCfunc := *(*LuaCFunction)(unsafe.Pointer(&oldptr))
-	return func(state *State) int {
-		L := unsafe.Pointer(state)
-		return oldCfunc(L)
-	}
+	return s.ffi.LuaAtpanic(s.luaL, panicf)
 }
 
 // Version returns the current version of the Lua runtime loaded in this state.

--- a/type.go
+++ b/type.go
@@ -146,17 +146,11 @@ func (s *State) ToUserData(idx int) unsafe.Pointer {
 	return s.ffi.LuaTouserdata(s.luaL, idx)
 }
 
-// ToGoFunction returns the Go representation of the Lua C function at idx, or nil if not a function.
-// See: https://www.lua.org/manual/5.4/manual.html#lua_tocfunction
-func (s *State) ToGoFunction(idx int) GoFunc {
-	fnptr := s.ffi.LuaTocfunction(s.luaL, idx)
-	if fnptr == nil {
-		return nil
-	}
-	return func(L *State) int {
-		cFunc := *(*LuaCFunction)(fnptr)
-		return cFunc(L.luaL)
-	}
+// ToCFunction returns the C function pointer at idx, or nil if not a C function.
+// There is no ToGoFunction because Go functions are not convertible once pushed onto the stack.
+// The returned pointer can be used with PushCFunctionPointer to push it back onto the stack.
+func (s *State) ToCFunction(idx int) unsafe.Pointer {
+	return s.ffi.LuaTocfunction(s.luaL, idx)
 }
 
 // RawLen returns the length of value at idx (arrays, strings, tables).

--- a/type_test.go
+++ b/type_test.go
@@ -96,32 +96,37 @@ func (s *Suite) TestTypeToGoFunction(assert *require.Assertions, L *lua.State) {
 	assert.Equal(lua.LUA_TFUNCTION, L.Type(-1))
 	assert.Equal("function", L.TypeName(L.Type(-1)))
 
-	goFunc := L.ToGoFunction(-1)
-	assert.NotNil(goFunc)
+	cFunc := L.ToCFunction(-1)
+	assert.NotNil(cFunc)
 
 	assert.NoError(L.PCall(0, 1, 0))
 	assert.Equal(expected, L.ToString(-1))
-
 	L.Pop(1)
+
+	L.PushCFunction(cFunc)
+	assert.NoError(L.PCall(0, 1, 0))
+	assert.Equal(expected, L.ToString(-1))
+	L.Pop(1)
+
 	err := L.LoadString("function test() return 42 end")
 	assert.NoError(err)
 
 	assert.True(L.IsFunction(-1))
 	assert.False(L.IsGoFunction(-1))
 
-	luaFunc := L.ToGoFunction(-1)
+	luaFunc := L.ToCFunction(-1)
 	assert.Nil(luaFunc)
 
 	L.Pop(1)
 	L.PushInteger(42)
 	assert.False(L.IsGoFunction(-1))
-	nonFunc := L.ToGoFunction(-1)
+	nonFunc := L.ToCFunction(-1)
 	assert.Nil(nonFunc)
 
 	L.Pop(1)
 	L.PushNil()
 	assert.False(L.IsGoFunction(-1))
-	nilFunc := L.ToGoFunction(-1)
+	nilFunc := L.ToCFunction(-1)
 	assert.Nil(nilFunc)
 }
 


### PR DESCRIPTION
Once you pushed the Go function onto Lua stack, it is impossible to  convert the pointer back to Go function.

While we can push back the pointer without any convertion and call it again.