### PR TITLE
breaking(api): abandon PushGoFunction and PushGoClousure, add NewCallback

### DIFF
--- a/state.go
+++ b/state.go
@@ -348,7 +348,7 @@ func (s *State) Unref(idx int, ref int) {
 
 type Reg struct {
 	Name string
-	Func GoFunc
+	Func uintptr
 }
 
 // SetFuncs registers a list of Go functions as Lua C API functions in the current state.
@@ -358,7 +358,7 @@ func (s *State) SetFuncs(l []*Reg, nup int) {
 	var ll = make([]LuaLReg, 0, len(l)+1)
 	for _, reg := range l {
 		name, _ := bytePtrFromString(reg.Name)
-		s.PushGoFunction(reg.Func)
+		s.PushCFunction(reg.Func)
 		ll = append(ll, LuaLReg{
 			Name: name,
 			// trampoline to the Go function

--- a/table_test.go
+++ b/table_test.go
@@ -452,10 +452,10 @@ func (s *Suite) TestTableMeta(assert *require.Assertions, L *lua.State) {
 	mtIdx := L.GetTop()
 
 	L.PushString("__call")
-	L.PushGoFunction(func(L *lua.State) int {
+	L.PushCFunction(lua.NewCallback(func(L *lua.State) int {
 		L.PushString("called")
 		return 1
-	})
+	}, L.Lib()))
 	L.SetTable(mtIdx)
 
 	L.SetIMetaTable(tblIdx)
@@ -482,10 +482,10 @@ func (s *Suite) TestTableMeta(assert *require.Assertions, L *lua.State) {
 	has = L.NewMetaTable("mt")
 	assert.True(has)
 	L.PushString("__call")
-	L.PushGoFunction(func(L *lua.State) int {
+	L.PushCFunction(lua.NewCallback(func(L *lua.State) int {
 		L.PushString("mt called")
 		return 1
-	})
+	}, L.Lib()))
 	L.SetTable(-3)
 	L.SetTop(tblIdx)
 

--- a/thread_test.go
+++ b/thread_test.go
@@ -169,7 +169,7 @@ func (s *Suite) TestThreadYield(assert *require.Assertions, t *testing.T) {
 		assert.NoError(L.YieldK(1, unsafe.Pointer(fc), fibCont))
 		return 1
 	}
-	L.PushGoFunction(fib)
+	L.PushCFunction(lua.NewCallback(fib, s.lib))
 	L.SetGlobal("fib")
 
 	assert.NoError(L.DoFile("testdata/resume.lua"))

--- a/type_test.go
+++ b/type_test.go
@@ -86,7 +86,7 @@ func (s *Suite) TestTypeToGoFunction(assert *require.Assertions, L *lua.State) {
 		return 1
 	}
 
-	L.PushGoFunction(testCFunc)
+	L.PushCFunction(lua.NewCallback(testCFunc, L.Lib()))
 
 	assert.True(L.IsGoFunction(-1))
 	assert.Equal(lua.LUA_TFUNCTION, L.Type(-1))
@@ -175,18 +175,18 @@ func (s *Suite) TestTypeToRawLen(assert *require.Assertions, L *lua.State) {
 }
 
 func (s *Suite) TestFunction(assert *require.Assertions, L *lua.State) {
-	L.PushGoFunction(func(L *lua.State) int {
+	L.PushCFunction(lua.NewCallback(func(L *lua.State) int {
 		number := L.ToNumber(1)
 		assert.Equal(number, 42.0)
 		return 0
-	})
+	}, L.Lib()))
 	L.SetGlobal("print_number")
 
-	L.PushGoFunction(func(L *lua.State) int {
+	L.PushCFunction(lua.NewCallback(func(L *lua.State) int {
 		x := L.CheckNumber(1)
 		L.PushNumber(x * 2)
 		return 1
-	})
+	}, L.Lib()))
 	L.SetGlobal("double_number")
 
 	assert.NoError(L.DoString(`print_number(double_number(21))`))
@@ -194,11 +194,11 @@ func (s *Suite) TestFunction(assert *require.Assertions, L *lua.State) {
 
 func (s *Suite) TestFunctionUpValue(assert *require.Assertions, L *lua.State) {
 	L.PushString("World")
-	L.PushGoClousure(func(L *lua.State) int {
+	L.PushCClousure(lua.NewCallback(func(L *lua.State) int {
 		upValue := L.ToString(L.UpValueIndex(1))
 		L.PushString("Hello, " + upValue)
 		return 1
-	}, 1)
+	}, L.Lib()), 1)
 	L.PushValue(-1)
 	assert.NoError(L.PCall(0, 1, 0))
 	assert.Equal("Hello, World", L.ToString(-1))
@@ -360,7 +360,7 @@ func (s *Suite) TestCheckType(assert *require.Assertions, L *lua.State) {
 	L.CheckType(-1, lua.LUA_TNIL)
 	L.Pop(1)
 
-	L.PushGoFunction(func(L *lua.State) int { return 0 })
+	L.PushCFunction(lua.NewCallback(func(L *lua.State) int { return 0 }, L.Lib()))
 	L.CheckType(-1, lua.LUA_TFUNCTION)
 	L.Pop(1)
 
@@ -389,7 +389,7 @@ func (s *Suite) TestCheckAny(assert *require.Assertions, L *lua.State) {
 	L.CheckAny(-1)
 	L.Pop(1)
 
-	L.PushGoFunction(func(L *lua.State) int { return 0 })
+	L.PushCFunction(lua.NewCallback(func(L *lua.State) int { return 0 }, L.Lib()))
 	L.CheckAny(-1)
 	L.Pop(1)
 

--- a/userdata_test.go
+++ b/userdata_test.go
@@ -68,7 +68,7 @@ func (s *Suite) TestUserData(assert *require.Assertions, L *lua.State) {
 
 	L.NewTable()
 	L.PushString("__index")
-	L.PushGoFunction(func(L *lua.State) int {
+	L.PushCFunction(lua.NewCallback(func(L *lua.State) int {
 		userdata := (*UserData)(L.ToUserData(1))
 		key := L.ToString(2)
 		switch key {
@@ -82,7 +82,7 @@ func (s *Suite) TestUserData(assert *require.Assertions, L *lua.State) {
 			L.PushNil()
 			return 1
 		}
-	})
+	}, L.Lib()))
 	L.SetTable(-3)
 	L.SetIMetaTable(-2)
 


### PR DESCRIPTION
`PushGoFunction` and `PushGoClosure` have been removed due to limitations with purego callbacks.

To avoid reaching the function limit, it's recommended to use `NewCallback` to create reusable global function pointers instead of creating new Go functions each time.